### PR TITLE
ＧＰＩをの初期化処理をメイン内に移動、強制終了時処理追加

### DIFF
--- a/LED
+++ b/LED
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# coding: utf-8
+# -*- coding: utf-8 -*-
+
+import threading
+import websocket
+import time
+
+#raspberry PiのGPIOを使えるように
+import RPi.GPIO as GPIO
+
+#Raspberry PI GPIO の初期化
+GPIO.setmode(GPIO.BOARD)
+GPIO.setup(16, GPIO.OUT)
+GPIO.setup(18, GPIO.OUT)
+
+class WebSocketClient:
+
+    def __init__(self, uri):
+        self.uri = uri
+        self.on_opened = None
+        self.on_messaged = None
+        self.on_closed = None
+        self.on_error = None
+        self.ws = None
+        self.timeout = 3
+
+    def open(self):
+        ''' WebSocketサーバに接続します '''
+        self.ws = websocket.WebSocketApp(
+            self.uri,
+            on_message=self.on_messaged,
+            on_error=self.on_error,
+            on_close=self.on_closed
+            )
+        self.ws.on_open = self.on_opened
+
+        # 接続処理後は別スレッドで待機
+        runner = threading.Thread(target=self.__run)
+        runner.setDaemon(True)
+        runner.start()
+
+        # 接続完了まで待機(タイムアウトの場合あり)
+        count = self.timeout
+        while not self.ws.sock.connected and count:
+            time.sleep(1)
+            count -= 1
+
+    def __run(self):
+        print "run"
+        self.ws.run_forever()
+
+    def send(self, message):
+        ''' 文字列を送信します '''
+        if not self.ws:
+            raise Exception("websocket is not open.")
+        self.ws.send(message)
+
+    def close(self):
+        ''' 接続を閉じます。 '''
+        self.ws.close()
+
+#messegeを受け取った時の処理
+def message_listener(ws, message):
+    print message
+    #LEDpin16_ON
+    if message == "led16_on":
+        GPIO.output(16, True)
+    #LEDpin16_OFF
+    if message == "led16_off":
+        GPIO.output(16, False)
+
+def closed_listener(ws):
+    print "closed"
+
+if __name__ == '__main__':
+        client = WebSocketClient('ws://192.168.1.102:8080/websocket')
+        client.on_messaged = message_listener
+        client.on_closed = closed_listener
+        client.open()
+        client.send('hoge')
+        while True:
+            time.sleep(1)
+            client.send("foo")
+            client.close()
+
+#GPIOを開放
+GPIO.cleanup()

--- a/LED
+++ b/LED
@@ -6,13 +6,6 @@ import threading
 import websocket
 import time
 
-#raspberry PiのGPIOを使えるように
-import RPi.GPIO as GPIO
-
-#Raspberry PI GPIO の初期化
-GPIO.setmode(GPIO.BOARD)
-GPIO.setup(16, GPIO.OUT)
-GPIO.setup(18, GPIO.OUT)
 
 class WebSocketClient:
 
@@ -74,15 +67,24 @@ def closed_listener(ws):
     print "closed"
 
 if __name__ == '__main__':
-        client = WebSocketClient('ws://192.168.1.102:8080/websocket')
-        client.on_messaged = message_listener
-        client.on_closed = closed_listener
-        client.open()
-        client.send('hoge')
-        while True:
+    #raspberry PiのGPIOを使えるように
+    #import RPi.GPIO as GPIO
+    GPIO.setmode(GPIO.BOARD)
+    GPIO.setup(16, GPIO.OUT)
+    GPIO.setup(18, GPIO.OUT)
+
+    client = WebSocketClient('ws://localhost:8080/websocket')
+    client.on_messaged = message_listener
+    client.on_closed = closed_listener
+    client.open()
+    client.send('hoge')
+    while True:
+        # ctrl+cで終了した時のためにtry-exceptでGPIO.cleanupを実行するようにします。
+        try:
             time.sleep(1)
             client.send("foo")
-            client.close()
-
-#GPIOを開放
-GPIO.cleanup()
+        except KeyboardInterrupt as ex:
+            print "closing"
+            #GPIOを開放
+            GPIO.cleanup()
+            raise ex

--- a/websocket_client.py
+++ b/websocket_client.py
@@ -5,7 +5,6 @@ import threading
 import websocket
 import time
 
-
 class WebSocketClient:
 
     def __init__(self, uri):
@@ -60,7 +59,7 @@ def closed_listener(ws):
     print "closed"
 
 if __name__ == '__main__':
-    client = WebSocketClient('ws://192.168.1.102:8080/websocket')
+    client = WebSocketClient('ws://localhost:8080/websocket')
     client.on_messaged = message_listener
     client.on_closed = closed_listener
     client.open()


### PR DESCRIPTION
お疲れ様です。

以下２点だけ気になったので変更しました。
まだ、ラズパイ上で動作確認していないですが、おねがいします。

- GPIOの初期化をメイン内で実行するように変更
- Ctrl+cで強制終了した時に、GPIO.cleanupを実行してから終了するように変更